### PR TITLE
Move integration test ready check to docker

### DIFF
--- a/test/integration/Ipv8Connector.spec.ts
+++ b/test/integration/Ipv8Connector.spec.ts
@@ -4,9 +4,12 @@ import Ipv8Connector from '../../src/Ipv8Connector'
 
 describe('Ipv8Connector.ts', function () {
   this.beforeAll(function (done) {
-    this.timeout(1200000)
+    this.timeout(120000)
+
     Ipv8DockerUtil.startIpv8Container()
-      .then(() => Ipv8DockerUtil.waitForContainersToBeReady().then(() => done()))
+      .then(() => Ipv8DockerUtil.waitForContainersToBeReady())
+      .then(() => done())
+      .catch(e => assert.fail(e))
   })
 
   this.afterAll(function (done) {

--- a/test/integration/client/Ipv8AttestationClient.spec.ts
+++ b/test/integration/client/Ipv8AttestationClient.spec.ts
@@ -4,9 +4,12 @@ import { Ipv8DockerUtil } from '../util/ipv8docker'
 
 describe('Ipv8AttestationClient.ts', function () {
   this.beforeAll(function (done) {
-    this.timeout(1200000)
+    this.timeout(120000)
+
     Ipv8DockerUtil.startIpv8Container()
-      .then(() => Ipv8DockerUtil.waitForContainersToBeReady().then(() => done()))
+      .then(() => Ipv8DockerUtil.waitForContainersToBeReady())
+      .then(() => done())
+      .catch(e => assert.fail(e))
   })
 
   this.afterAll(function (done) {

--- a/test/integration/ipv8/Dockerfile
+++ b/test/integration/ipv8/Dockerfile
@@ -6,8 +6,10 @@ RUN apt-get update
 RUN apt-get install libsodium-dev git gcc --yes
 RUN git clone --depth=50 --branch=master https://github.com/Tribler/py-ipv8.git pyipv8
 RUN pip install --no-cache-dir -r ./pyipv8/requirements.txt
+RUN pip install requests
 
 RUN touch __init__.py
 COPY . .
 
 CMD ["python", "main.py"]
+HEALTHCHECK --interval=1s --timeout=5s --start-period=120s --retries=3 CMD [ "python", "healthcheck.py" ]

--- a/test/integration/ipv8/healthcheck.py
+++ b/test/integration/ipv8/healthcheck.py
@@ -1,0 +1,23 @@
+import sys
+import requests
+import json 
+
+try:
+    peers_request = requests.get('http://localhost:14410/attestation?type=peers')
+    attributes_request = requests.get('http://localhost:14410/attestation?type=attributes')
+
+    if peers_request.status_code != 200 or attributes_request.status_code != 200:
+        exit(1)
+
+    peers = json.loads(peers_request.text)
+
+    if 'K1ifTZ++hPN4UqU24rSc/czfYZY=' not in peers or 'eGU/YRXWJB18VQf8UbOoIhW9+xM=' not in peers:
+        exit(1)
+
+    attributes = json.loads(attributes_request.text)[0]
+
+    if attributes[0] != 'time_for_beer':
+        exit(1)
+
+except:
+    exit(1)


### PR DESCRIPTION
Closes #15 

This PR moves the pre-checks for the integrations tests to the `HEALTHCHECK` system of Docker. Move these checks to the container itself makes it easier to maintain and solve the problem of random failures. To confirm this, the integration tests for this PR ran > 10 times on both a local environment as the CI. None of the runs failed so far.