### PR TITLE
Make the signature of verify compatible with core

### DIFF
--- a/test/integration/Ipv8Connector.spec.ts
+++ b/test/integration/Ipv8Connector.spec.ts
@@ -87,7 +87,7 @@ describe('Ipv8Connector.ts', function () {
       })
     })
 
-    brewerConnector.verify(peers.employee.did, { 'approve': 'link:discipl:ipv8:perm:4145d2dc63874fe601b8d8cd3efbfd07edff1a04eadee019be2490505ad4ec26' }, peers.employer.did)
+    brewerConnector.verify(peers.employer.did, { 'approve': 'link:discipl:ipv8:perm:4145d2dc63874fe601b8d8cd3efbfd07edff1a04eadee019be2490505ad4ec26' }, peers.employer.did)
       .then(link => expect(link).to.eq('link:discipl:ipv8:perm:4145d2dc63874fe601b8d8cd3efbfd07edff1a04eadee019be2490505ad4ec26'))
       .then(() => done())
   })


### PR DESCRIPTION
When implementing integration tests I discovered that the current implementation of the `verify` method is not compatible with @discipl/core, (https://github.com/discipl/core/blob/master/src/index.js#L157)
