### PR TITLE
Improve reliability and configurability

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -37,6 +37,12 @@
             {
                 "args": "none"
             }
+        ],
+        "@typescript-eslint/camelcase": [
+            "warn",
+            {
+                "properties": "never"
+            }
         ]
     }
 }

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ IPv8 uses two representations of this public key, the hexadecimal format and a _
 ### Temporary and permanent links
 When a new attestation is made a temporary link, indicated with `temp`, will be received. This temporary link has the attribute name in base64 encoding as reference. This makes it possible to use a JSON object as the attribute name. The reason for the existence of this temporary link is a limitation by IPv8. An attribute does not really exist in the trustchain until it is attested by another peer. Once the attribute is attested a permanent link, indicated with `perm`, will be received. This link has the hash of the trustchain block that attested the claim as reference.
 
+## Race conditions
+The IPv8 connector is built upon the REST interface of IPv8 peers. Since IPv8 itself is also a network-based application, race conditions may happen. A typical example is a situation where the creation of a claim is immediately followed by a attest of this claim. In this situation, the new claim might be not synced across the entire IPv8 network yet. The peer that needs to attest this claim won't be able to find it.
+
+Prevention of this situation can be fairly difficult since it depends on the IPv8 peer the connector is talking to. A basic rule that can be applied is to make sure that all peers are connected to the network. It is also recommended to implement code that will catch potential errors and handles them in a way that fits your needs.
+
 ## Tests
 Unit- and integration tests can be ran by execution `npm run test`. Docker is needed to run these tests. A container with an ipv8 server will be automatically started using the `Dockerfile` provided at [./test/integration/ipv8](./test/integration/ipv8). The unit- and integration tests can also be run seperately with the commands `npm run test:unit` and `npm run test:integration`.
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@discipl/core-ipv8",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discipl/core-ipv8",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Discipl Core Connector for IPV8 network overlays",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/Ipv8Connector.ts
+++ b/src/Ipv8Connector.ts
@@ -136,7 +136,7 @@ class Ipv8Connector extends BaseConnector {
         return this.attestTemporaryLink(ssid, attributeName, attestationValue)
       } else if (indicator === this.LINK_PERMANTENT_INDICATOR) {
         const attributeHash = refSplit[1]
-        return this.attestPermantentLink(ssid, attributeHash, attestationValue)
+        return this.attestPermanentLink(ssid, attributeHash, attestationValue)
       }
 
       throw new Error(`Unknown link indicator: ${indicator}`)
@@ -175,7 +175,7 @@ class Ipv8Connector extends BaseConnector {
    * @param attributeHash Hash of the attribute to attest
    * @param attestationValue Value to attest the attribute with
    */
-  async attestPermantentLink (ssid: string, attributeHash: string, attestationValue: string): Promise<string> {
+  async attestPermanentLink (ssid: string, attributeHash: string, attestationValue: string): Promise<string> {
     const attester = this.extractPeerFromDid(ssid)
     const block = (await this.ipv8TrustchainClient.getBlocksForUser(attester.publicKey)).find(blocks => blocks.hash === attributeHash)
     const claim = (await this.ipv8AttestationClient.getOutstanding()).find(outstanding => outstanding.attributeName === block?.transaction.name)

--- a/src/Ipv8Connector.ts
+++ b/src/Ipv8Connector.ts
@@ -133,10 +133,10 @@ class Ipv8Connector extends BaseConnector {
       const indicator = refSplit[0]
       if (indicator === this.LINK_TEMPORARY_INIDACOTR) {
         const attributeName = refSplit[1]
-        return this.attestClaim(ssid, attributeName, attestationValue)
+        return this.attestTemporaryLink(ssid, attributeName, attestationValue)
       } else if (indicator === this.LINK_PERMANTENT_INDICATOR) {
         const attributeHash = refSplit[1]
-        return this.reattestClaim(ssid, attributeHash, attestationValue)
+        return this.attestPermantentLink(ssid, attributeHash, attestationValue)
       }
 
       throw new Error(`Unknown link indicator: ${indicator}`)
@@ -153,9 +153,9 @@ class Ipv8Connector extends BaseConnector {
    * @param attributeName Base64 encoded attribute to attest
    * @param attestationValue Value to attest the attribute with
    */
-  async attestClaim (ssid: string, attributeName: string, attestationValue: string): Promise<string> {
+  async attestTemporaryLink (ssid: string, attributeName: string, attestationValue: string): Promise<string> {
     const attester = this.extractPeerFromDid(ssid)
-    const claim = (await this.ipv8AttestationClient.getOutstanding()).find(outstanding => outstanding.attributeName === attributeName)
+    const claim = await this.ipv8AttestationClient.findOutstanding(attributeName)
 
     if (!claim) {
       throw new Error(`Attestation request for "${attributeName}" could not be found`)
@@ -175,7 +175,7 @@ class Ipv8Connector extends BaseConnector {
    * @param attributeHash Hash of the attribute to attest
    * @param attestationValue Value to attest the attribute with
    */
-  async reattestClaim (ssid: string, attributeHash: string, attestationValue: string): Promise<string> {
+  async attestPermantentLink (ssid: string, attributeHash: string, attestationValue: string): Promise<string> {
     const attester = this.extractPeerFromDid(ssid)
     const block = (await this.ipv8TrustchainClient.getBlocksForUser(attester.publicKey)).find(blocks => blocks.hash === attributeHash)
     const claim = (await this.ipv8AttestationClient.getOutstanding()).find(outstanding => outstanding.attributeName === block?.transaction.name)

--- a/src/Ipv8Connector.ts
+++ b/src/Ipv8Connector.ts
@@ -402,7 +402,7 @@ class Ipv8Connector extends BaseConnector {
       )
     )
 
-    const readyPromise = new Promise(async (resolve) => {
+    const readyPromise: Promise<void> = new Promise(async (resolve) => {
       const peers = await this.ipv8AttestationClient.getPeers()
 
       if (peers.includes(observingPeer.mid)) {

--- a/src/Ipv8Connector.ts
+++ b/src/Ipv8Connector.ts
@@ -371,7 +371,7 @@ class Ipv8Connector extends BaseConnector {
    * @param accessorPrivkey Private key of did that is observing
    */
   async observeVerificationRequests (did: string, claimFilter: { did: string } = null, accessorDid: string = null, accessorPrivkey: string = null): Promise<ObserveResult<VerificationRequest>> {
-    const peer = this.extractPeerFromDid(did)
+    const observingPeer = this.extractPeerFromDid(did)
     const filterPeers = switchMap((outstanding: OutstandingVerifyRequest[]) => outstanding.filter(r => r.peerMid === this.extractPeerFromDid(claimFilter.did).mid))
 
     // Retreive all outstanding verification requests in the given interval
@@ -381,7 +381,7 @@ class Ipv8Connector extends BaseConnector {
       outstanding => iif(() => claimFilter !== null, filterPeers(outstanding), outstanding.pipe(switchMap(m => m))),
       mergeMap(request =>
         // To convert a verification request into a link the trustchain block is needed
-        from(this.ipv8TrustchainClient.getBlocksForUser(peer.publicKey))
+        from(this.ipv8TrustchainClient.getBlocksForUser(observingPeer.publicKey))
           .pipe(
             map(blocks => blocks.find(b => b.transaction.name === request.name)),
             filter(block => block !== undefined),
@@ -405,7 +405,7 @@ class Ipv8Connector extends BaseConnector {
     const readyPromise = new Promise(async (resolve) => {
       const peers = await this.ipv8AttestationClient.getPeers()
 
-      if (peers.includes(peer.mid)) {
+      if (peers.includes(observingPeer.mid)) {
         resolve()
       }
     })

--- a/src/Ipv8Connector.ts
+++ b/src/Ipv8Connector.ts
@@ -402,15 +402,7 @@ class Ipv8Connector extends BaseConnector {
       )
     )
 
-    const readyPromise: Promise<void> = new Promise(async (resolve) => {
-      const peers = await this.ipv8AttestationClient.getPeers()
-
-      if (peers.includes(observingPeer.mid)) {
-        resolve()
-      }
-    })
-
-    return { observable: observarable, readyPromise: readyPromise }
+    return { observable: observarable, readyPromise: Promise.resolve() }
   }
 }
 

--- a/src/Ipv8Connector.ts
+++ b/src/Ipv8Connector.ts
@@ -383,7 +383,7 @@ class Ipv8Connector extends BaseConnector {
                 claim: { data: request.name, previous: prevLink },
                 link: link,
                 did: ownerDid,
-                // A mid cannot be converted back to the public key, so no did is generated
+                // A mid cannot be converted back to the public key, so no did
                 verifier: { did: null, mid: request.peerMid }
               }
             })
@@ -391,7 +391,15 @@ class Ipv8Connector extends BaseConnector {
       )
     )
 
-    return { observable: observarable, readyPromise: Promise.resolve() }
+    const readyPromise = new Promise(async (resolve) => {
+      const peers = await this.ipv8AttestationClient.getPeers()
+
+      if (peers.includes(peer.mid)) {
+        resolve()
+      }
+    })
+
+    return { observable: observarable, readyPromise: readyPromise }
   }
 }
 

--- a/src/types/core-baseconnector.ts
+++ b/src/types/core-baseconnector.ts
@@ -44,6 +44,6 @@ declare module '@discipl/core-baseconnector' {
 
   export type ObserveResult<T> = {
     observable: Observable<T>;
-    readyPromise: Promise<any>;
+    readyPromise: Promise<void>;
   }
 }

--- a/src/types/ipv8-connector.ts
+++ b/src/types/ipv8-connector.ts
@@ -25,3 +25,10 @@ export interface Peer {
     mid: string;
     publicKey: string;
 }
+
+export interface ConfigOptions {
+    VERIFICATION_REQUEST_MAX_RETRIES?: number;
+    VERIFICATION_REQUEST_RETRY_TIMEOUT_MS?: number;
+    VERIFICATION_MINIMAl_MATCH?: number;
+    OBSERVE_VERIFICATION_POLL_INTERVAL_MS?: number;
+}

--- a/test/integration/Ipv8Connector.spec.ts
+++ b/test/integration/Ipv8Connector.spec.ts
@@ -80,7 +80,7 @@ describe('Ipv8Connector.ts', function () {
     employeeConnector.configure(peers.employee.url)
 
     const observeResult = await employeeConnector.observeVerificationRequests(peers.employee.did, { did: peers.brewer.did })
-    await observeResult.readPromise
+    await observeResult.readyPromise
     const subscription = observeResult.observable.subscribe({
       next: c => {
         employeeConnector.ipv8AttestationClient.allowVerify('eGU/YRXWJB18VQf8UbOoIhW9+xM=', c.claim.data)

--- a/test/integration/ipv8/Dockerfile
+++ b/test/integration/ipv8/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 # Libsodium is not installed by default but required for IPv8
 RUN apt-get update
 RUN apt-get install libsodium-dev git gcc --yes
-RUN git clone --depth=50 --branch=master https://github.com/Tribler/py-ipv8.git pyipv8
+RUN git clone --depth=1 --branch=2.1 https://github.com/Tribler/py-ipv8.git pyipv8
 RUN pip install --no-cache-dir -r ./pyipv8/requirements.txt
 RUN pip install requests
 

--- a/test/integration/ipv8/healthcheck.py
+++ b/test/integration/ipv8/healthcheck.py
@@ -3,15 +3,31 @@ import requests
 import json 
 
 try:
-    peers_request = requests.get('http://localhost:14410/attestation?type=peers')
+    peers_request0 = requests.get('http://localhost:14410/attestation?type=peers')
+    peers_request1 = requests.get('http://localhost:14411/attestation?type=peers')
+    peers_request2 = requests.get('http://localhost:14412/attestation?type=peers')
     attributes_request = requests.get('http://localhost:14410/attestation?type=attributes')
 
-    if peers_request.status_code != 200 or attributes_request.status_code != 200:
+    if peers_request0.status_code != 200 or attributes_request.status_code != 200:
         exit(1)
 
-    peers = json.loads(peers_request.text)
+    if peers_request1.status_code != 200:
+        exit(1)
 
-    if 'K1ifTZ++hPN4UqU24rSc/czfYZY=' not in peers or 'eGU/YRXWJB18VQf8UbOoIhW9+xM=' not in peers:
+    if peers_request2.status_code != 200:
+        exit(1)
+
+    peers0 = json.loads(peers_request0.text)
+    peers1 = json.loads(peers_request1.text)
+    peers2 = json.loads(peers_request2.text)
+
+    if 'K1ifTZ++hPN4UqU24rSc/czfYZY=' not in peers0 or 'eGU/YRXWJB18VQf8UbOoIhW9+xM=' not in peers0:
+        exit(1)
+
+    if 'safeqEkAA2ouwLQ2dayMRWEfsH0=' not in peers1 or 'eGU/YRXWJB18VQf8UbOoIhW9+xM=' not in peers1:
+        exit(1)
+
+    if 'safeqEkAA2ouwLQ2dayMRWEfsH0=' not in peers2 or 'K1ifTZ++hPN4UqU24rSc/czfYZY=' not in peers2:
         exit(1)
 
     attributes = json.loads(attributes_request.text)[0]

--- a/test/unit/Ipv8Connector.spec.ts
+++ b/test/unit/Ipv8Connector.spec.ts
@@ -150,7 +150,7 @@ describe('Ipv8Connector.ts', function () {
       sandbox.stub(trustchainClient, 'getBlocksForUser').resolves([])
       sandbox.stub(attestationClient, 'getOutstanding').resolves([{ attributeName: 'some_claim', peerMid: 'owner', metadata: '' }])
 
-      expect(connector.attestPermantentLink('', '1234', 'nope'))
+      expect(connector.attestPermanentLink('', '1234', 'nope'))
         .to.eventually.be.rejected
         .and.to.be.and.instanceOf(Error)
         .and.have.property('message', 'Attribute with hash "1234" could not be found')

--- a/test/unit/Ipv8Connector.spec.ts
+++ b/test/unit/Ipv8Connector.spec.ts
@@ -346,12 +346,5 @@ describe('Ipv8Connector.ts', function () {
         done()
       })
     })
-
-    it('readyPromise should resolve if the observing did is found in the network', async function () {
-      this.timeout(100)
-      const observeResult = await connector.observeVerificationRequests('did')
-
-      return assert.isFulfilled(observeResult.readyPromise, 'The readyPromise was not fulfilled')
-    })
   })
 })

--- a/test/unit/Ipv8Connector.spec.ts
+++ b/test/unit/Ipv8Connector.spec.ts
@@ -137,23 +137,21 @@ describe('Ipv8Connector.ts', function () {
       expect(attestLink).to.eq('link:discipl:ipv8:perm:1234')
     })
 
-    it('should not be able to attest a none existing claim', function () {
+    it('should not be able to attest a none existing claim', async function () {
       sandbox.stub(attestationClient, 'getOutstanding').resolves([])
 
-      expect(connector.attestTemporaryLink('', 'Y2xhaW0=', 'approve'))
-        .to.eventually.be.rejected
-        .and.to.be.and.instanceOf(Error)
-        .and.have.property('message', 'Attestation request for "Y2xhaW0=" could not be found')
+      const result = connector.attestTemporaryLink('', 'Y2xhaW0=', 'approve')
+
+      return assert.isRejected(result, /Attestation request for "Y2xhaW0=" could not be found/)
     })
 
-    it('should not be able to reattest a none existing claim', function () {
+    it('should not be able to reattest a none existing claim', async function () {
       sandbox.stub(trustchainClient, 'getBlocksForUser').resolves([])
       sandbox.stub(attestationClient, 'getOutstanding').resolves([{ attributeName: 'some_claim', peerMid: 'owner', metadata: '' }])
 
-      expect(connector.attestPermanentLink('', '1234', 'nope'))
-        .to.eventually.be.rejected
-        .and.to.be.and.instanceOf(Error)
-        .and.have.property('message', 'Attribute with hash "1234" could not be found')
+      const result = connector.attestPermanentLink('', '1234', 'nope')
+
+      return assert.isRejected(result, /Attribute with hash "1234" could not be found/)
     })
 
     describe('should give an error when a invalid link is given', async function () {

--- a/test/unit/Ipv8Connector.spec.ts
+++ b/test/unit/Ipv8Connector.spec.ts
@@ -8,7 +8,7 @@ import { TrustchainBlock } from '../../src/types/ipv8'
 import stringify from 'json-stable-stringify'
 import { Base64Utils } from '../../src/utils/base64'
 import { take } from 'rxjs/operators'
-import { Subscription, config } from 'rxjs'
+import { Subscription } from 'rxjs'
 use(chaiAsPromised)
 
 /* eslint-disable @typescript-eslint/camelcase */
@@ -140,7 +140,7 @@ describe('Ipv8Connector.ts', function () {
     it('should not be able to attest a none existing claim', function () {
       sandbox.stub(attestationClient, 'getOutstanding').resolves([])
 
-      expect(connector.attestClaim('', 'Y2xhaW0=', 'approve'))
+      expect(connector.attestTemporaryLink('', 'Y2xhaW0=', 'approve'))
         .to.eventually.be.rejected
         .and.to.be.and.instanceOf(Error)
         .and.have.property('message', 'Attestation request for "Y2xhaW0=" could not be found')
@@ -150,7 +150,7 @@ describe('Ipv8Connector.ts', function () {
       sandbox.stub(trustchainClient, 'getBlocksForUser').resolves([])
       sandbox.stub(attestationClient, 'getOutstanding').resolves([{ attributeName: 'some_claim', peerMid: 'owner', metadata: '' }])
 
-      expect(connector.reattestClaim('', '1234', 'nope'))
+      expect(connector.attestPermantentLink('', '1234', 'nope'))
         .to.eventually.be.rejected
         .and.to.be.and.instanceOf(Error)
         .and.have.property('message', 'Attribute with hash "1234" could not be found')

--- a/test/unit/Ipv8Connector.spec.ts
+++ b/test/unit/Ipv8Connector.spec.ts
@@ -1,7 +1,7 @@
 import Ipv8Connector from '../../src/Ipv8Connector'
 import { Ipv8AttestationClient } from '../../src/client/Ipv8AttestationClient'
 import sinon from 'sinon'
-import { use, expect } from 'chai'
+import { use, expect, assert } from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import { Ipv8TrustchainClient } from '../../src/client/Ipv8TrustchainClient'
 import { TrustchainBlock } from '../../src/types/ipv8'
@@ -292,6 +292,7 @@ describe('Ipv8Connector.ts', function () {
       sandbox.stub(connector, 'extractPeerFromDid')
         .withArgs('some_did').returns({ mid: 'abcde', publicKey: '' })
         .withArgs('did').returns({ mid: 'efghi', publicKey: '' })
+      sandbox.stub(attestationClient, 'getPeers').resolves(['abcde', 'efghi'])
     })
 
     it('should emit when a new outstanding request is available', async function () {
@@ -332,6 +333,13 @@ describe('Ipv8Connector.ts', function () {
         expect(results).to.have.lengthOf(0)
         done()
       })
+    })
+
+    it('readyPromise should resolve if the observing did is found in the network', async function () {
+      this.timeout(100)
+      const observeResult = await connector.observeVerificationRequests('did')
+
+      return assert.isFulfilled(observeResult.readyPromise, 'The readyPromise was not fulfilled')
     })
   })
 })

--- a/test/unit/Ipv8Connector.spec.ts
+++ b/test/unit/Ipv8Connector.spec.ts
@@ -8,7 +8,7 @@ import { TrustchainBlock } from '../../src/types/ipv8'
 import stringify from 'json-stable-stringify'
 import { Base64Utils } from '../../src/utils/base64'
 import { take } from 'rxjs/operators'
-import { Subscription } from 'rxjs'
+import { Subscription, config } from 'rxjs'
 use(chaiAsPromised)
 
 /* eslint-disable @typescript-eslint/camelcase */
@@ -27,6 +27,20 @@ describe('Ipv8Connector.ts', function () {
 
   it('should have the name "ipv8"', function () {
     expect(connector.getName()).to.equal('ipv8')
+  })
+
+  it('should let the configure method override the default options', function () {
+    connector.configure('', {
+      VERIFICATION_REQUEST_MAX_RETRIES: 1,
+      VERIFICATION_REQUEST_RETRY_TIMEOUT_MS: 2,
+      VERIFICATION_MINIMAl_MATCH: 0.3,
+      OBSERVE_VERIFICATION_POLL_INTERVAL_MS: 4
+    })
+
+    expect(connector.VERIFICATION_REQUEST_MAX_RETRIES).to.be.equal(1)
+    expect(connector.VERIFICATION_REQUEST_RETRY_TIMEOUT_MS).to.be.equal(2)
+    expect(connector.VERIFICATION_MINIMAl_MATCH).to.be.equal(0.3)
+    expect(connector.OBSERVE_VERIFICATION_POLL_INTERVAL_MS).to.be.equal(4)
   })
 
   it('should extract a IPv8 peer from a did', function () {

--- a/test/unit/client/Ipv8AtterstationClient.spec.ts
+++ b/test/unit/client/Ipv8AtterstationClient.spec.ts
@@ -30,15 +30,15 @@ describe('Ipv8AttestationClient.ts', function () {
   })
 
   describe('#findOutstanding', function () {
-    it('should try again if the oustanding request is not found', async function () {
+    it('should try 5 times if the oustanding request is not found', async function () {
       const mock = sinon.stub(attestationClient, 'getOutstanding')
-        .onFirstCall().resolves([])
-        .onSecondCall().resolves([{ attributeName: 'attribute', metadata: '', peerMid: 'abcde' }])
+        .resolves([])
+        .onCall(4).resolves([{ attributeName: 'attribute', metadata: '', peerMid: 'abcde' }])
 
       const outstanding = await attestationClient.findOutstanding('attribute')
 
       expect(outstanding).to.deep.eq({ attributeName: 'attribute', metadata: '', peerMid: 'abcde' })
-      expect(mock.callCount).to.eq(2)
+      expect(mock.callCount).to.eq(5)
     })
   })
 


### PR DESCRIPTION
## General
This PR improves the overall reliability and configurability of the connector.

- A configuration object can now be passed to the `configure` method
- The  `observeVerificationRequests` method has a implementation for the `readyPromise`. This prevents the method to start observing while the actual observer is not present yet in the IPv8 network
- Additional pre-checks are added to ensure the testing environment is ready
- Introduction of the `findOutstanding(attributeName)` method for the `AttestationClient`

The last change will reduce errors in cases where a request for attestation is followed almost immediately with the attestation. In such cases as request might not be synced yet with the rest of the IPv8 network and thus no outstanding verification request could be found. I believe this is the cause of the random CI failures.